### PR TITLE
Replace () with (void) as empty parameter list.

### DIFF
--- a/appcode/rboot-api.c
+++ b/appcode/rboot-api.c
@@ -21,7 +21,7 @@ extern "C" {
 #endif
 
 // get the rboot config
-rboot_config ICACHE_FLASH_ATTR rboot_get_config() {
+rboot_config ICACHE_FLASH_ATTR rboot_get_config(void) {
 	rboot_config conf;
 	spi_flash_read(BOOT_CONFIG_SECTOR * SECTOR_SIZE, (uint32*)&conf, sizeof(rboot_config));
 	return conf;
@@ -62,7 +62,7 @@ bool ICACHE_FLASH_ATTR rboot_set_config(rboot_config *conf) {
 }
 
 // get current boot rom
-uint8 ICACHE_FLASH_ATTR rboot_get_current_rom() {
+uint8 ICACHE_FLASH_ATTR rboot_get_current_rom(void) {
 	rboot_config conf;
 	conf = rboot_get_config();
 	return conf.current_rom;

--- a/appcode/rboot-api.h
+++ b/appcode/rboot-api.h
@@ -37,7 +37,7 @@ typedef struct {
  *  @note   Returns rboot_config (defined in rboot.h) allowing you to modify any values
  *          in it, including the ROM layout.
 */
-rboot_config ICACHE_FLASH_ATTR rboot_get_config();
+rboot_config ICACHE_FLASH_ATTR rboot_get_config(void);
 
 /**	@brief	Write rBoot configuration to flash memory
  *	@param	conf pointer to a rboot_config structure containing configuration to save
@@ -54,7 +54,7 @@ bool ICACHE_FLASH_ATTR rboot_set_config(rboot_config *conf);
  *  @note   Get the currently selected boot ROM (the currently running ROM, as long as
  *          you haven't changed it since boot)
 */
-uint8 ICACHE_FLASH_ATTR rboot_get_current_rom();
+uint8 ICACHE_FLASH_ATTR rboot_get_current_rom(void);
 
 /**	@brief	Set the index of current ROM
  *	@param	rom The index of the ROM to use on next boot


### PR DESCRIPTION
() means no parameters specified in ANSI C, while
(void) means no parameters at all (which is what's meant).