### PR TITLE
Allow RBOOT_EXTRA_INCDIR to include a wrapper rboot.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ else ifeq ($(SPI_SPEED), 80)
 	E2_OPTS += -80
 endif
 
-RBOOT_EXTRA_INCDIR := $(addprefix -I,$(RBOOT_EXTRA_INCDIR))
+CFLAGS += $(addprefix -I,$(RBOOT_EXTRA_INCDIR))
 
 .SECONDARY:
 
@@ -96,7 +96,7 @@ $(RBOOT_FW_BASE):
 
 $(RBOOT_BUILD_BASE)/rboot-stage2a.o: rboot-stage2a.c rboot-private.h rboot.h
 	@echo "CC $<"
-	$(Q) $(CC) $(CFLAGS) $(RBOOT_EXTRA_INCDIR) -c $< -o $@
+	$(Q) $(CC) $(CFLAGS) -c $< -o $@
 
 $(RBOOT_BUILD_BASE)/rboot-stage2a.elf: $(RBOOT_BUILD_BASE)/rboot-stage2a.o
 	@echo "LD $@"
@@ -108,11 +108,11 @@ $(RBOOT_BUILD_BASE)/rboot-hex2a.h: $(RBOOT_BUILD_BASE)/rboot-stage2a.elf
 
 $(RBOOT_BUILD_BASE)/rboot.o: rboot.c rboot-private.h rboot.h $(RBOOT_BUILD_BASE)/rboot-hex2a.h
 	@echo "CC $<"
-	$(Q) $(CC) $(CFLAGS) -I$(RBOOT_BUILD_BASE) $(RBOOT_EXTRA_INCDIR) -c $< -o $@
+	$(Q) $(CC) $(CFLAGS) -I$(RBOOT_BUILD_BASE) -c $< -o $@
 
 $(RBOOT_BUILD_BASE)/%.o: %.c %.h
 	@echo "CC $<"
-	$(Q) $(CC) $(CFLAGS) $(RBOOT_EXTRA_INCDIR) -c $< -o $@
+	$(Q) $(CC) $(CFLAGS) -c $< -o $@
 
 $(RBOOT_BUILD_BASE)/%.elf: $(RBOOT_BUILD_BASE)/%.o
 	@echo "LD $@"

--- a/rboot-private.h
+++ b/rboot-private.h
@@ -12,7 +12,7 @@ typedef int int32;
 typedef unsigned int uint32;
 typedef unsigned char uint8;
 
-#include "rboot.h"
+#include <rboot.h>
 
 #define NOINLINE __attribute__ ((noinline))
 


### PR DESCRIPTION
This is the change I mentioned in SuperHouse/esp-open-rtos#136 . It lets us put a wrapper rboot.h in the top-level directory, and just set the additional flags we want.

(The reason I chose this way instead of using Makefile flags is that this way we can reference the same wrapper rboot.h when compiling our user support code from a different Makefile, instead of having to find a way to add the same Makefile variables into two different Makefile hierarchies.)

*Commit message follows:*

The wrapper rboot.h can optionally use gcc include_next to pick up the
default rboot.h.

This allows modifying the rboot.h file without changing anything in the
rboot directory (useful for esp-open-rtos where we like using git
submodules for upstream code.)