### PR TITLE
Custom default rom map

### DIFF
--- a/rboot.c
+++ b/rboot.c
@@ -364,9 +364,13 @@ uint32 NOINLINE find_image(void) {
 		ets_memset(romconf, 0x00, sizeof(rboot_config));
 		romconf->magic = BOOT_CONFIG_MAGIC;
 		romconf->version = BOOT_CONFIG_VERSION;
+#ifndef BOOT_CONFIG_DEFAULTS
 		romconf->count = 2;
 		romconf->roms[0] = SECTOR_SIZE * (BOOT_CONFIG_SECTOR + 1);
 		romconf->roms[1] = (flashsize / 2) + (SECTOR_SIZE * (BOOT_CONFIG_SECTOR + 1));
+#else
+		set_defaults(romconf);
+#endif
 #ifdef BOOT_CONFIG_CHKSUM
 		romconf->chksum = calc_chksum((uint8*)romconf, (uint8*)&romconf->chksum);
 #endif


### PR DESCRIPTION
Ability to compile custom default rom map (or full config) directly into the code instead of providing separate struct to flash at the config location. Especially if for some reason the config gets corrupted during operation, with this approach a compatible default map is written whereas with the currently supported method only the hardcoded default would be written...

This appears o be a natural addition to the integration capabilities added. I'm currently using an outdated copy of rboot with a lot of changes and would like to move back to the master branch because I found a lot of improvements that make my code changes obsolete. The default map appears  to be one of a few areas that would still require a custom change (and I don't want to just flash the default map for the reasons provided above). 

To enable, define BOOT_CONFIG_DEFAULTS in rboot-integration.h and add a function that sets the default values. Simplistic rboot-integration.h for just this purpose could look like this:

#ifndef __RBOOT_INTEGRATION_H__
#define __RBOOT_INTEGRATION_H__

#include "..\rboot\rboot-private.h"

#define BOOT_CONFIG_DEFAULTS 

void set_defaults(rboot_config *romconf) {
    romconf->count = 4;
    romconf->roms[0] = 0x010000;
    romconf->roms[1] = 0x100000;
    romconf->roms[2] = 0x200000;
    romconf->roms[3] = 0x300000;
}

#endif