### PR TITLE
Allow for special fallback rom slot

### DIFF
--- a/rboot.c
+++ b/rboot.c
@@ -456,12 +456,26 @@ uint32 NOINLINE find_image(void) {
 		// for normal mode try each previous rom
 		// until we find a good one or run out
 		updateConfig = TRUE;
-		romToBoot--;
-		if (romToBoot < 0) romToBoot = romconf->count - 1;
-		if (romToBoot == romconf->current_rom) {
-			// tried them all and all are bad!
-			ets_printf("No good rom available.\r\n");
-			return 0;
+		if (romconf->mode & MODE_FALLBACK) {
+			if (romToBoot == 0) {
+				// tried them all incl. fallback and all are bad!
+				ets_printf("No good rom available.\r\n");
+				return 0;
+			}
+			romToBoot--;
+			if (romToBoot < 1) romToBoot = romconf->count - 1;
+			if (romToBoot == romconf->current_rom) {
+				// tried them all and all are bad! -> fallback
+				romToBoot = 0;
+			}
+		} else {
+			romToBoot--;
+			if (romToBoot < 0) romToBoot = romconf->count - 1;
+			if (romToBoot == romconf->current_rom) {
+				// tried them all and all are bad!
+				ets_printf("No good rom available.\r\n");
+				return 0;
+			}
 		}
 		runAddr = check_image(romconf->roms[romToBoot]);
 	}

--- a/rboot.h
+++ b/rboot.h
@@ -63,6 +63,7 @@ extern "C" {
 #define MODE_GPIO_ROM    0x01
 #define MODE_TEMP_ROM    0x02
 #define MODE_GPIO_ERASES_SDKCONFIG 0x04
+#define MODE_FALLBACK 0x08
 
 #define RBOOT_RTC_MAGIC 0x2334ae68
 #define RBOOT_RTC_READ 1


### PR DESCRIPTION
I've moved OTA capabilities and a lot of other one time or rare case functionality (like AP with mini webserver for first time configuration of SSID/PW) into one dedicated ROM instead of duplicating that functionality in all ROMs wasting space. To properly select the last good ROM, the bootloader needs to be aware of this setup and pick the next ROM to check accordingly. I've added a new flag similar to the ERASE_SDKCONFIG flag to facilitate this - could be done via defines as well as I don't expect this behavior to change after design time. If another ROM wants to switch to this functionality, it can set the temp ROM in RTC-mem and force a soft-reboot e.g. forcing a watchdog timeout in an endless loop.