### PR TITLE
New option: skip to next image via GPIO

### DIFF
--- a/rboot.c
+++ b/rboot.c
@@ -139,7 +139,7 @@ static uint32 check_image(uint32 readpos) {
 #define RTC_GPIO_IN_DATA						(REG_RTC_BASE + 0x08C)
 #define RTC_GPIO_CONF							(REG_RTC_BASE + 0x090)
 #define PAD_XPD_DCDC_CONF						(REG_RTC_BASE + 0x0A0)
-static uint32 get_gpio16(void) {
+static void config_gpio16_as_input(void) {
 	// set output level to 1
 	WRITE_PERI_REG(RTC_GPIO_OUT, (READ_PERI_REG(RTC_GPIO_OUT) & (uint32)0xfffffffe) | (uint32)(1));
 
@@ -147,7 +147,9 @@ static uint32 get_gpio16(void) {
 	WRITE_PERI_REG(PAD_XPD_DCDC_CONF, (READ_PERI_REG(PAD_XPD_DCDC_CONF) & 0xffffffbc) | (uint32)0x1);	// mux configuration for XPD_DCDC and rtc_gpio0 connection
 	WRITE_PERI_REG(RTC_GPIO_CONF, (READ_PERI_REG(RTC_GPIO_CONF) & (uint32)0xfffffffe) | (uint32)0x0);	//mux configuration for out enable
 	WRITE_PERI_REG(RTC_GPIO_ENABLE, READ_PERI_REG(RTC_GPIO_ENABLE) & (uint32)0xfffffffe);	//out disable
+}
 
+static uint32 get_gpio16(void) {
 	return (READ_PERI_REG(RTC_GPIO_IN_DATA) & 1);
 }
 
@@ -267,6 +269,10 @@ uint32 NOINLINE find_image(void) {
 
 	rboot_config *romconf = (rboot_config*)buffer;
 	rom_header *header = (rom_header*)buffer;
+
+#if defined (BOOT_GPIO_ENABLED) && (BOOT_GPIO_NUM == 16)
+	config_gpio16_as_input();
+#endif
 
 #if defined BOOT_DELAY_MICROS && BOOT_DELAY_MICROS > 0
 	// delay to slow boot (help see messages when debugging)

--- a/rboot.c
+++ b/rboot.c
@@ -279,6 +279,9 @@ uint32 NOINLINE find_image(void) {
 	ets_delay_us(BOOT_DELAY_MICROS);
 #endif
 
+	// set baudrate to 115200:
+	uart_div_modify(0, 2*26000000 / 115200); // 26 MHz is the actual xtal frequency
+
 	ets_printf("\r\nrBoot v1.4.0 - richardaburton@gmail.com\r\n");
 
 	// read rom header

--- a/rboot.h
+++ b/rboot.h
@@ -29,9 +29,14 @@ extern "C" {
 // uncomment to enable GPIO booting
 //#define BOOT_GPIO_ENABLED
 
+// uncomment to enable skipping to the next image via GPIO
+// note: cannot be used together with BOOT_GPIO_ENABLED
+//#define BOOT_GPIO_NEXTIMAGE_ENABLED
+
 // set the GPIO number used by MODE_GPIO_ROM (will
 // default to 16 if not manually set), only applicable
-// when BOOT_GPIO_ENABLED is enabled
+// when either BOOT_GPIO_ENABLED or BOOT_GPIO_NEXTIMAGE_ENABLED
+// is enabled
 //#define BOOT_GPIO_NUM 16
 
 // uncomment to include .irom0.text section in the checksum


### PR DESCRIPTION
Hi Richard,

I have added a new feature to rBoot, because the existing GPIO feature didn't suit my needs. It might be useful to others as well.

Background: I am using rBoot with 2 slots. Firmware updates (downloading and flashing) are performed by the user program, where the active program in slot 0 will flash into slot 1 or vice versa.
In the situation where flashing was succesful (ROM checksum is ok), but the program itself contains a bug, rBoot will keep booting into that new ROM image. If the networking or firmware upgrade code is broken, I'm stuck.
The 'normal' GPIO functionality is no solution here, because it can only boot into a predefined slot. If this slot happens to contain the 'broken' firmware, it doesn't help.
The new option uses GPIO to simply mark the current slot as 'invalid', and lets the existing code search for an other ROM to boot from. In my case, it will find the previous firmware in the other slot, which can be used to re-flash a new (hopefully fixed) image.

Commit f04392b contains the new option mentioned above.
In commit 3c68cc9 I have separated the reading of the GPIO pin from configuring it as an input. In my opinion, the pin should be set as input as early in the boot process as possible, to prevent large currents when the pin is also driven externally. Furthermore, once the pin is configured as an input, there is a lot more time for the voltage at the pin to stabilize at the required level before the pin state is read back.

I couldn't convince Github to exclude bb7421d from the pull request, please ignore it.

Cheers,

Matthijs