### PR TITLE
move RBOOT_INTEGRATION handling to rboot.h

### DIFF
--- a/appcode/rboot-api.c
+++ b/appcode/rboot-api.c
@@ -18,10 +18,6 @@
 #include <mem.h>
 #endif
 
-#ifdef RBOOT_INTEGRATION
-#include <rboot-integration.h>
-#endif
-
 #include "rboot-api.h"
 
 #ifdef __cplusplus

--- a/appcode/rboot-bigflash.c
+++ b/appcode/rboot-bigflash.c
@@ -5,10 +5,6 @@
 // See license.txt for license terms.
 //////////////////////////////////////////////////
 
-#ifdef RBOOT_INTEGRATION
-#include <rboot-integration.h>
-#endif
-
 typedef unsigned int uint32;
 typedef unsigned char uint8;
 

--- a/rboot.c
+++ b/rboot.c
@@ -5,10 +5,6 @@
 // See license.txt for license terms.
 //////////////////////////////////////////////////
 
-#ifdef RBOOT_INTEGRATION
-#include <rboot-integration.h>
-#endif
-
 #include "rboot-private.h"
 #include <rboot-hex2a.h>
 

--- a/rboot.h
+++ b/rboot.h
@@ -12,6 +12,10 @@
 extern "C" {
 #endif
 
+#ifdef RBOOT_INTEGRATION
+#include <rboot-integration.h>
+#endif
+
 // uncomment to use only c code
 // if you aren't using gcc you may need to do this
 //#define BOOT_NO_ASM


### PR DESCRIPTION
Everything including rboot.h need to take RBOOT_INTEGRATION into
consideration as rboot.h contains BOOT_* #ifdefs, so move the
RBOOT_INTEGRATION handling to there instead of repeating it everywhere (and
risk forgetting it, like it was the case for rboot-api.h).

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>