### PR TITLE
Make rboot.h self contained

### DIFF
--- a/appcode/rboot-bigflash.c
+++ b/appcode/rboot-bigflash.c
@@ -5,9 +5,6 @@
 // See license.txt for license terms.
 //////////////////////////////////////////////////
 
-typedef unsigned int uint32;
-typedef unsigned char uint8;
-
 #include <rboot.h>
 
 #ifdef BOOT_BIG_FLASH

--- a/rboot-private.h
+++ b/rboot-private.h
@@ -8,10 +8,6 @@
 // See license.txt for license terms.
 //////////////////////////////////////////////////
 
-typedef int int32;
-typedef unsigned int uint32;
-typedef unsigned char uint8;
-
 #include <rboot.h>
 
 #define NOINLINE __attribute__ ((noinline))
@@ -19,9 +15,6 @@ typedef unsigned char uint8;
 #define ROM_MAGIC	   0xe9
 #define ROM_MAGIC_NEW1 0xea
 #define ROM_MAGIC_NEW2 0x04
-
-#define TRUE 1
-#define FALSE 0
 
 // buffer size, must be at least 0x10 (size of rom_header_new structure)
 #define BUFFER_SIZE 0x100

--- a/rboot.h
+++ b/rboot.h
@@ -12,6 +12,8 @@
 extern "C" {
 #endif
 
+#include <c_types.h> // uint* types
+
 #ifdef RBOOT_INTEGRATION
 #include <rboot-integration.h>
 #endif

--- a/testload1.c
+++ b/testload1.c
@@ -2,7 +2,7 @@
 // richardaburton@gmail.com
 // See license.txt for license terms.
 
-#include "testload1.h"
+#include <c_types.h>
 
 void call_user_start(void) {
 	uint8 loop;

--- a/testload1.h
+++ b/testload1.h
@@ -1,7 +1,0 @@
-// Copyright 2015 Richard A Burton
-// richardaburton@gmail.com
-// See license.txt for license terms.
-
-typedef unsigned int uint32;
-typedef unsigned short uint16;
-typedef unsigned char uint8;

--- a/testload2.c
+++ b/testload2.c
@@ -2,7 +2,7 @@
 // richardaburton@gmail.com
 // See license.txt for license terms.
 
-#include "testload2.h"
+#include <c_types.h>
 
 void call_user_start(void) {
 	uint8 loop;

--- a/testload2.h
+++ b/testload2.h
@@ -1,7 +1,0 @@
-// Copyright 2015 Richard A Burton
-// richardaburton@gmail.com
-// See license.txt for license terms.
-
-typedef unsigned int uint32;
-typedef unsigned short uint16;
-typedef unsigned char uint8;


### PR DESCRIPTION
rboot.h uses the nonstandard uint8 / uint32 types without defining them,
causing breakage if rboot.h (or other headers including it like rboot-api.h)
are included without locally defining these types.

The espressif SDK includes a nonstandard c_types.h header containing
definitions for uint8/uint32/TRUE/FALSE, so include that in rboot.h and drop
all the local definitions.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>