### PR TITLE
Fixes to get rid of compiler warnings. Don't use malloc/free wrappers.

### DIFF
--- a/appcode/rboot-bigflash.c
+++ b/appcode/rboot-bigflash.c
@@ -27,6 +27,7 @@ uint8 rBoot_mmap_1 = 0xff;
 uint8 rBoot_mmap_2 = 0xff;
 
 // this function must remain in iram
+void IRAM_ATTR Cache_Read_Enable_New(void);
 void IRAM_ATTR Cache_Read_Enable_New(void) {
 	
 	if (rBoot_mmap_1 == 0xff) {


### PR DESCRIPTION
I think if you don't use the ugly Espressif os_malloc and os_free defines, you also don't need the kludge to find out where they're defined.

This commit also fixes a compiler because a global function is defined but not declared.