### PR TITLE
Makefile: don't use -Os and -O3 together. Also get rid of linker option "--no-check-sections".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ else
 Q := @
 endif
 
-CFLAGS    = -Os -O3 -Wpointer-arith -Wundef -Werror -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH
-LDFLAGS   = -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static
+CFLAGS    = -Os -Wpointer-arith -Wundef -Werror -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH
+LDFLAGS   = -nostdlib -u call_user_start -Wl,-static
 LD_SCRIPT = eagle.app.v6.ld
 
 E2_OPTS = -quiet -bin -boot0


### PR DESCRIPTION
 Contrary to what the documentation says, the last one specified wins, so the code is compiled -O3 and not -Os. Remove the -Os shrinks the code considerately.