### PR TITLE
Makefile: don't use -Os and -O3 together.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ else
 Q := @
 endif
 
-CFLAGS    = -Os -O3 -Wpointer-arith -Wundef -Werror -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH
+CFLAGS    = -Os -Wpointer-arith -Wundef -Werror -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH
 LDFLAGS   = -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static
 LD_SCRIPT = eagle.app.v6.ld
 


### PR DESCRIPTION
 Contrary to what the documentation says, the last one specified wins, so the code is compiled -O3 and not -Os. Remove the -Os shrinks the code considerately.