### PR TITLE
ld: don't use --no-check-sections, gcc: don't use -Os and -O3 together.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ Q := @
 endif
 
 CFLAGS    = -Os -Wpointer-arith -Wundef -Werror -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH
-LDFLAGS   = -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static
+LDFLAGS   = -nostdlib -u call_user_start -Wl,-static
 LD_SCRIPT = eagle.app.v6.ld
 
 E2_OPTS = -quiet -bin -boot0

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ else
 Q := @
 endif
 
-CFLAGS    = -Os -O3 -Wpointer-arith -Wundef -Werror -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH
+CFLAGS    = -Os -Wpointer-arith -Wundef -Werror -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH
 LDFLAGS   = -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static
 LD_SCRIPT = eagle.app.v6.ld
 


### PR DESCRIPTION
ld: don't use --no-check-sections
    
    It's a dangerous option and doesn't seem to be necessary.

gcc: don't use -Os and -O3 together.
    
    Contrary to what the documentation says, the last one specified wins, so
    the code is compiled -O3 and not -Os. Remove the -Os shrinks the code
    considerately.