### PR TITLE
big-flash: changes to app code.

### DIFF
--- a/appcode/rboot-bigflash.c
+++ b/appcode/rboot-bigflash.c
@@ -26,6 +26,14 @@ extern void Cache_Read_Enable(uint32, uint32, uint32);
 uint8 rBoot_mmap_1 = 0xff;
 uint8 rBoot_mmap_2 = 0xff;
 
+#ifdef BOOT_RTC_ENABLED
+typedef union
+{
+	rboot_rtc_data	data;
+	uint32_t 		overlay[4];
+} rboot_rtc_data_overlay_t;
+#endif
+
 // this function must remain in iram
 void IRAM_ATTR Cache_Read_Enable_New(void) {
 	
@@ -36,24 +44,25 @@ void IRAM_ATTR Cache_Read_Enable_New(void) {
 		SPIRead(BOOT_CONFIG_SECTOR * SECTOR_SIZE, &conf, sizeof(rboot_config));
 
 #ifdef BOOT_RTC_ENABLED
-		// rtc support here isn't written ideally, we don't read the whole structure and
-		// we don't check the checksum. However this code is only run on first boot, so
-		// the rtc data should have just been set and the user app won't have had chance
-		// to corrupt it or suspend or anything else that might upset it. And if
-		// it were bad what should we do anyway? We can't just ignore bad data here, we
-		// need it. But the main reason is that this code must be in iram, which is in
-		// very short supply, doing this "properly" increases the size about 3x
+		{
+			const rboot_rtc_data_overlay_t *rtc_in_iospace;
+			rboot_rtc_data_overlay_t rtc_in_dram;
+			unsigned int ix;
 
-		// used only to calculate offset into structure, should get optimized out
-		rboot_rtc_data rtc;
-		uint8 off = (uint8*)&rtc.last_rom - (uint8*)&rtc;
-		// get the four bytes containing the one of interest
-		volatile uint32 *rtcd = (uint32*)(0x60001100 + (RBOOT_RTC_ADDR*4) + (off & ~3));
-		val = *rtcd;
-		// extract the one of interest
-		val = ((uint8*)&val)[off & 3];
-		// get address of rom
-		val = conf.roms[val];
+			rtc_in_iospace = (const rboot_rtc_data_overlay_t *)(0x60001100 + (RBOOT_RTC_ADDR * 4));
+
+			for(ix = 0; ix < sizeof(rtc_in_dram.overlay) / sizeof(rtc_in_dram.overlay[0]); ix++)
+				rtc_in_dram.overlay[ix] = rtc_in_iospace->overlay[ix];
+
+			// Don't check for next_mode == RBOOT_TEMP_ROM and neither use next_slot
+			// 		because they already have been reset by rboot at this point.
+			// Trust rboot to have selected the correct rom slot instead.
+
+			if(rtc_in_dram.data.magic == RBOOT_RTC_MAGIC)
+				val = conf.roms[rtc_in_dram.data.last_rom];
+			else
+				val = conf.roms[conf.current_rom];
+		}
 #else
 		val = conf.roms[conf.current_rom];
 #endif


### PR DESCRIPTION
The current implementation doesn't check the magic number. If rboot is not yet updated for RTC mode (and your image IS), it will crash.
    
Also I think this code is cleaner.
    
It will add a few bytes to IRAM usage though.