### PR TITLE
Makefile: add mode 2048b.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ else ifeq ($(SPI_SIZE), 1M)
 	E2_OPTS += -1024
 else ifeq ($(SPI_SIZE), 2M)
 	E2_OPTS += -2048
+else ifeq ($(SPI_SIZE), 2Mb)
+	E2_OPTS += -2048b
 else ifeq ($(SPI_SIZE), 4M)
 	E2_OPTS += -4096
 endif


### PR DESCRIPTION
The default 2048 mode is defined as 512/512, mode 3. There is a newer 2048 mode which is defined as 1024/1024 and which I happen to use.
    
Prior to the SDK partition stuff (SDK 3), it was no problem to have 512/512 image and use it as 1024/1024, but now the SDK enforces the flash map type.

This needs a related patch in esptool2 to work.