### PR TITLE
Add 8M/16M support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ else ifeq ($(SPI_SIZE), 2Mb)
 	E2_OPTS += -2048b
 else ifeq ($(SPI_SIZE), 4M)
 	E2_OPTS += -4096
+else ifeq ($(SPI_SIZE), 8M)
+	E2_OPTS += -8192
+else ifeq ($(SPI_SIZE), 16M)
+	E2_OPTS += -16384
 endif
 ifeq ($(SPI_MODE), qio)
 	E2_OPTS += -qio


### PR DESCRIPTION
rboot code supports 8M/16Mbyte operation but the makefile and esptool2 don't have the requisite bits.

Not tested on hardware as I've no Esp8266 devices handy with 8Mbyte or 16Mbytes!